### PR TITLE
chore(IntervalTree): fix docstring for map

### DIFF
--- a/src/classes/intervalTree.js
+++ b/src/classes/intervalTree.js
@@ -140,7 +140,7 @@ class IntervalTree {
     }
 
     /** Value Mapper. Walk through every node and map node value to another value
-    * @param callback(value, key) - function to be called for each tree item
+    * @param callback(value,key) - function to be called for each tree item
     */
     map(callback) {
         const tree = new IntervalTree();


### PR DESCRIPTION
Right now, the documentation for `map` is somewhat broken due to an additional character. This PR aims to fix that.

Screenshot (current):
![Screen Shot 2020-02-12 at 17 53 59](https://user-images.githubusercontent.com/17609157/74376378-c147f700-4dc0-11ea-9650-759822e164ea.png)
