### PR TITLE
Update a type and fix a typo

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -72,7 +72,7 @@ declare class IntervalTree<T = any> {
     readonly items: Array<{key:Interval, value: Value<T>}>;
 
     isEmpty(): boolean;
-    clean(): void;
+    clear(): void;
     insert(key: Interval | NumericTuple, value?: Value<T>) : Node<T>;
     exist(key: Interval | NumericTuple, value?: Value<T>): boolean;
     remove(key: Interval | NumericTuple, value?: Value<T>) : Node<T>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -64,7 +64,7 @@ export declare class Node<T> {
 declare class IntervalTree<T = any> {
     constructor()
 
-    root: Node<T>;
+    root: Node<T> | null;
 
     readonly size: number;
     readonly keys: Node<T>[];


### PR DESCRIPTION
This PR fixes two small inconsistencies:
- It looks like `IntervalTree.root` can be null if the tree is empty
- There's no `clean` member function but there is a `clear` member function