### PR TITLE
fix: finds the lowest intersecting interval

### DIFF
--- a/src/classes/intervalTree.js
+++ b/src/classes/intervalTree.js
@@ -422,8 +422,12 @@ class IntervalTree {
         let curr = node;
         while (curr && curr != this.nil_node) {
             if (curr.less_than(search_node)) {
-                if (curr.intersect(search_node) && (!best || curr.less_than(best))) best = curr;
-                curr = curr.right;
+                if (curr.intersect(search_node)) {
+                    best = curr;
+                    curr = curr.left;
+                } else {
+                    curr = curr.right;
+                }
             } else {
                 if (!best || curr.less_than(best)) best = curr;
                 curr = curr.left;

--- a/test/intervalTree.js
+++ b/test/intervalTree.js
@@ -318,6 +318,13 @@ describe('#IntervalTree', function() {
             let iterator = tree.iterate([3,8]);
             expect(iterator.next().value).to.deep.equal([1,3]);
         });
+        it('Finds the lowest intersecting interval regardless of tree structure', function () {
+            let tree = new IntervalTree();
+            let ints = [[6,8],[5,12],[4,7],[1,5]];
+            for (let int of ints) tree.insert(int);
+            let iterator = tree.iterate([5,5]);
+            expect(iterator.next().value).to.deep.equal([1,5]);
+        });
         it('May find first forward interval when there is no intersection', function () {
             let tree = new IntervalTree();
             let ints = [[6,8],[1,3],[5,12],[1,1],[5,7]];


### PR DESCRIPTION
I found a bug in my previous implementation that the tests didn't catch. So I've added a new test that catches it and fixed the implementation to pass the test.

Essentially, the problem was that if a node was found that was less than and also intersecting with the search node, the algorithm wouldn't search any further left. In the case of an intersecting node, we always want to look further left to find the lowest intersecting node possible.

Let me know if you find any issues/have any concerns!